### PR TITLE
Image migration

### DIFF
--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/App_LocalResources/View.resx
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/App_LocalResources/View.resx
@@ -165,4 +165,28 @@
   <data name="ThereAreTotalOf.Text" xml:space="preserve">
     <value>There are a total of</value>
   </data>
+  <data name="MigrateImage.Text" xml:space="preserve">
+    <value>Migrate images</value>
+  </data>
+  <data name="OriginFolderPath.Text" xml:space="preserve">
+    <value>Origin Folder Path</value>
+  </data>
+  <data name="DestinationPathCannotNullEmpty.Text" xml:space="preserve">
+    <value>Destination Path cannot be null or empty</value>
+  </data>
+  <data name="ImagesWereMigratedSuccessfully.Text" xml:space="preserve">
+    <value>images were migrated successfully</value>
+  </data>
+  <data name="OriginFolderPathCannotNullEmpty.Text" xml:space="preserve">
+    <value>Origin Folder Path cannot be null or empty</value>
+  </data>
+  <data name="SourcePathCannotNullEmpty.Text" xml:space="preserve">
+    <value>Source Path cannot be null or empty</value>
+  </data>
+  <data name="YouHaveMigrateAfter.Text" xml:space="preserve">
+    <value>You have to migrate the images after having migrated the posts.</value>
+  </data>
+  <data name="NoImagesMigrated.Text" xml:space="preserve">
+    <value>No images were migrated, the images already exist in the destination file or do not exist in the source folder.</value>
+  </data>
 </root>

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Constants/Constant.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Constants/Constant.cs
@@ -93,6 +93,6 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Constants
         /// <summary>
         /// The default category name.
         /// </summary>
-        public const string DefaultCategoryName = "Uncategorized";
+        public const string DefaultCategoryName = "Business";
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
@@ -1,0 +1,40 @@
+﻿using DotNetNuke.Web.Api;
+using System.Web.Http;
+using DotNetNuke.Security;
+using System.Threading.Tasks;
+using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contract;
+using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Constants;
+
+namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
+{
+    /// <summary>
+    /// Controller for handling HubSpot related operations.
+    /// </summary>
+    [SupportedModules(Constant.SupportedModules)]
+    [DnnModuleAuthorize(AccessLevel = SecurityAccessLevel.Edit)]
+    [ValidateAntiForgeryToken]
+    public class EasyDNNNewsController : DnnApiController
+    {
+        private readonly IEasyDNNNewsRepository _easyDNNNewsRepository;
+
+        /// <summary>
+        /// Constructor for EasyDNNNewsController.
+        /// </summary>
+        /// <param name="hubspotRepository">The repository to use for EasyDNNNews related operations.</param>
+        public EasyDNNNewsController(IEasyDNNNewsRepository easyDNNNewsRepository)
+        {
+            _easyDNNNewsRepository = easyDNNNewsRepository;
+        }
+
+        /// <summary>
+        /// Migrate images to EasyDNNNews.
+        /// </summary>
+        /// <param name="originFolderPath"></param>
+        /// <returns></returns>
+        public async Task<IHttpActionResult> MigrateImagesToEasyDNNNews([FromBody] string originFolderPath)
+        {
+            var result = await _easyDNNNewsRepository.MigrateImagesToEasyDNNNews(originFolderPath);
+            return Ok(result);
+        }
+    }
+}

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/HubspotController.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/HubspotController.cs
@@ -154,6 +154,5 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
                 return Ok(Localization.GetString("MissingAccessToken.Text", ResourceFile));
             }
         }
-
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Models/EasyDNNNews.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Models/EasyDNNNews.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Web;
 
 namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Models
 {

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Web;
+﻿using System.Threading.Tasks;
 using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Models;
-using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.ViewModels;
 
 namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contract
 {
     public interface IEasyDNNNewsRepository
     {
         Task<int> AddEasyDNNNews(EasyDNNNews entity);
+        Task<bool> AddEasyDNNNewsCategories(EasyDNNNewsCategories entity);
+        Task<bool> AddEasyDNNNewsCategoryList(EasyDNNNewsCategoryList entity);
+        Task<EasyDNNNewsCategoryList> GetCategoryListByName(string categoryName);
+        Task<int> MigrateImagesToEasyDNNNews(string originFolderPath);
+        Task<bool> CopyImageToFolderAsync(string sourcePath, string articleImage, string destinationPath);
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.csproj
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -89,6 +90,7 @@
   <ItemGroup>
     <Compile Include="Components\FeatureController.cs" />
     <Compile Include="Constants\Constant.cs" />
+    <Compile Include="Controllers\EasyDNNNewsController.cs" />
     <Compile Include="Controllers\HubspotController.cs" />
     <Compile Include="Data\DapperContext.cs" />
     <Compile Include="Models\EasyDNNNews.cs" />
@@ -164,6 +166,12 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Module.build" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="client-app\src\components\HubSpotSettings.vue" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="client-app\src\components\MigrateImage.vue" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">.0</VisualStudioVersion>

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/assets/api.js
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/assets/api.js
@@ -1,7 +1,4 @@
 import axios from "axios";
-import { getUrlBase } from "../assets/utils";
-
-var baseUrl = `${getUrlBase("Hubspot")}`;
 
 export function antiForgeryToken() {
     const service = window?.$?.ServicesFramework?.();
@@ -24,7 +21,7 @@ export
 }
 export
     async function makeRequest(dnnConfig, endpoint, method = 'get', data = null, accessToken = null) {
-    const url = `${baseUrl}/${endpoint}`;
+    const url = `${endpoint}`;
     let headers = {
         'Content-Type': 'application/json',
         moduleid: dnnConfig.moduleId,

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/assets/utils.js
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/assets/utils.js
@@ -40,7 +40,11 @@ export function goHome() {
 
 export function getUrlBase(serviceName) {
     const url = new URL(window.location.href);
-    return `${url.origin}/API/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator/${serviceName}`;
+    if (serviceName != null && serviceName.length > 0) {
+        return `${url.origin}/API/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator/${serviceName}`;
+    } else {
+        return `${url.origin}/API/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator/`;
+    }
 }
 
 export function getCookie(name) {

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/components/HubSpotSettings.vue
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/components/HubSpotSettings.vue
@@ -32,7 +32,7 @@
 <script setup>
 import { inject, ref, } from 'vue';
 import { makeRequest } from '../assets/api.js';
-import { getCookie } from '../assets/utils.js';
+import { getCookie, getUrlBase } from '../assets/utils.js';
 
 // Injected dependencies
 const dnnConfig = inject("dnnConfig");
@@ -45,7 +45,8 @@ let scope = ref('');
 const accessToken = getCookie('access_token');
 
 const getSettings = async () => {
-    const result = await makeRequest(dnnConfig, 'GetSettings', 'get', null, accessToken);
+    var endpoint = `${getUrlBase()}Hubspot/GetSettings`
+    const result = await makeRequest(dnnConfig, endpoint, 'get', null, accessToken);
     if (result) {
         clientId.value = result.ClientId;
         clientSecret.value = result.ClientSecret;
@@ -62,7 +63,8 @@ const handleSubmit = async (event) => {
         RedirectUri: redirectUri.value,
         Scope: scope.value
     };
-    const response = await makeRequest(dnnConfig, 'UpdateSettings', 'post', data);
+    var endpoint = `${getUrlBase()}Hubspot/UpdateSettings`
+    const response = await makeRequest(dnnConfig, endpoint, 'post', data);
     console.log(response);
 };
 

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/components/MigrateImage.vue
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/client-app/src/components/MigrateImage.vue
@@ -1,0 +1,45 @@
+﻿<template>
+    <div class="card">
+        <div class="card-body custom-module">
+            <div class="dnnFormMessage dnnFormInfo">{{ resx.YouHaveMigrateAfter }}</div>
+            <h5><span v-if="numberMigratedImages > 0">
+                    {{ resx.ThereAreTotalOf }} {{ numberMigratedImages }} {{ resx.ImagesWereMigratedSuccessfully }}
+                </span>
+                {{ numberMigratedImages == 0 && numberMigratedImages != null ? resx.NoImagesMigrated : '' }} </h5>
+            <div v-if="isLoading" class="spinner"></div>
+            <form @submit="handleSubmit" class="dnnForm">
+                <div class="dnnFormItem">
+                    <label for="originFolderPath" class="dnnLabel">{{ resx.OriginFolderPath }}</label>
+                    <input v-model="originFolderPath" type="text" id="originFolderPath" class="dnnFormInput" required />
+                </div>
+                <div class="dnnActions dnnClear">
+                    <button type="submit" class="dnnPrimaryAction">{{ resx.MigrateImage }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { inject, ref, } from 'vue';
+import { makeRequest } from '../assets/api.js';
+import { getUrlBase } from "../assets/utils.js";
+
+// Injected dependencies
+const dnnConfig = inject("dnnConfig");
+const resx = inject("resx");
+
+let originFolderPath = ref('');
+let numberMigratedImages = ref(null);
+let isLoading = ref(false);
+
+const handleSubmit = async (event) => {
+    event.preventDefault();
+    isLoading.value = true;
+    var endpoint = `${getUrlBase()}EasyDNNNews/MigrateImagesToEasyDNNNews`
+    const response = await makeRequest(dnnConfig, endpoint, 'post', originFolderPath.value);
+    isLoading.value = false;
+    numberMigratedImages.value = response;
+    console.log(response);
+};
+</script>

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/module.css
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/module.css
@@ -52,6 +52,11 @@
     max-width: 66.666667%;
 }
 
+.col-12 {
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
 .custom-module .dnnFormItem input[type="text"],
 .custom-module .dnnFormItem input[type="password"],
 .custom-module .dnnFormItem input[type="email"],
@@ -68,4 +73,23 @@
 
 .custom-module .dnnLabel {
     text-align: left;
+}
+
+.spinner {
+    border: 16px solid #f3f3f3;
+    border-top: 16px solid #3498db;
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
 }


### PR DESCRIPTION
I've made improvements to HubSpot's post migration method by modifying it to store the image name in the ArticleImage column of the EasyDNNNews table, based on the URL of the image coming from HubSpot.

Additionally, I have created a method to migrate the images. This method operates by providing the path of the directory that contains the images to be migrated. Using the image name as a reference, the method performs a recursive search in the provided directory and copies the first image it finds to the EasyDNNNews structure. This is done only if the image exists. If the path does not exist, the method creates it, naming the folder with the ArticleId. This implementation ensures that only one image is copied, avoiding duplicates.

To handle cases of null data, I have implemented relevant validations. In the user interface, I have incorporated a loading indicator (spinner) to indicate when the migration process is in progress.
![image](https://github.com/UpendoVentures/HubSpot-EasyDnnNews-Blog-Migrator/assets/48692645/62f56e26-c42e-4cd3-866a-c1d884326aad)
![image](https://github.com/UpendoVentures/HubSpot-EasyDnnNews-Blog-Migrator/assets/48692645/dc089a8c-2eae-44e3-9938-c3929db52cbd)
![image](https://github.com/UpendoVentures/HubSpot-EasyDnnNews-Blog-Migrator/assets/48692645/5cc6a06b-3f84-4086-b947-5d638c0aeb32)
