### PR TITLE
Fix url images

### DIFF
--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
@@ -19,6 +19,7 @@ using DotNetNuke.Security;
 using System.Threading.Tasks;
 using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contract;
 using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Constants;
+using UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.ViewModels;
 
 namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
 {
@@ -49,6 +50,28 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
         public async Task<IHttpActionResult> MigrateImagesToEasyDNNNews([FromBody] string originFolderPath)
         {
             var result = await _easyDNNNewsRepository.MigrateImagesToEasyDNNNews(originFolderPath);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Remove duplicate images.
+        /// </summary>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<IHttpActionResult> RemoveDuplicateImages()
+        {
+            var result = await _easyDNNNewsRepository.RemoveDuplicateImages();
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Replace image urls.
+        /// <paramref name="parameters"/>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<IHttpActionResult> ReplaceImageUrls([FromBody] ReplaceImageUrlParams parameters)
+        {
+            var result = await _easyDNNNewsRepository.ReplaceImageUrls(parameters.DomainToReplace, parameters.PartialPath,parameters.SkipSegments);
             return Ok(result);
         }
     }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
@@ -74,5 +74,17 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
             var result = await _easyDNNNewsRepository.ReplaceImageUrls(parameters.DomainToReplace, parameters.PartialPath,parameters.SkipSegments);
             return Ok(result);
         }
+
+        /// <summary>
+        /// Replace absolute urls.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<IHttpActionResult> ReplaceAbsoluteUrls([FromBody] ReplaceImageUrlParams parameters)
+        {
+            var result = await _easyDNNNewsRepository.ReplaceAbsoluteUrls(parameters.DomainToReplace);
+            return Ok(result);
+        }
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
@@ -28,5 +28,6 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contr
         Task<bool> CopyImageToFolderAsync(string sourcePath, string articleImage, string destinationPath);
         Task<int> RemoveDuplicateImages();
         Task<int> ReplaceImageUrls(string domainToReplace, string partialPath, int skipSegments);
+        Task<int> ReplaceAbsoluteUrls(string domainToReplace);
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
@@ -26,5 +26,7 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contr
         Task<EasyDNNNewsCategoryList> GetCategoryListByName(string categoryName);
         Task<int> MigrateImagesToEasyDNNNews(string originFolderPath);
         Task<bool> CopyImageToFolderAsync(string sourcePath, string articleImage, string destinationPath);
+        Task<int> RemoveDuplicateImages();
+        Task<int> ReplaceImageUrls(string domainToReplace, string partialPath, int skipSegments);
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.csproj
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="DotNetNuke.Web" Version="9.11.0" />
     <PackageReference Include="DotNetNuke.Web.Client" Version="9.11.0" />
     <PackageReference Include="DotNetNuke.WebApi" Version="9.11.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
@@ -120,6 +121,7 @@
     <Compile Include="ViewModels\HubspotAccessTokenSetting.cs" />
     <Compile Include="ViewModels\HubspotSetting.cs" />
     <Compile Include="ViewModels\ImageInHubspot.cs" />
+    <Compile Include="ViewModels\ReplaceImageUrlParams.cs" />
     <Compile Include="ViewModels\TokenResponse.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/ViewModels/ReplaceImageUrlParams.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/ViewModels/ReplaceImageUrlParams.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.ViewModels
+{
+    public class ReplaceImageUrlParams
+    {
+        public string DomainToReplace { get; set; }
+        public string PartialPath { get; set; }
+        public int SkipSegments { get; set; }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
URL of the images and links pointed to the site in production.

## Description
I implemented the methods where we can pass the search parameters to make it more dynamic.
I have implemented the methods to convert the absolute paths of the images into relative paths.
Additionally, I have developed a method to eliminate duplicate images that are found both in the 'ArticleImage' column (main image) and in the summary and content of the post. This has been done to avoid redundancy of images on the same blog.
I implemented the methods to fix the img and href tag links still pointing to production.

## How Has This Been Tested?
I tested the methods locally by passing several example parameters:
"DomainToReplace": "http://www.junk-works.ca"
"DomainToReplace": "//www.junk-works.ca"
"DomainToReplace": "http://www.junk-king.com"

Also replace, for example, http://middlesex.junk-king.com with "/locations/middlesex/" which is how it works on the production site but with a redirect. With this method we do not need the redirect
<a href="http://middlesex.junk-king.com">Massachusetts</a>, <a href="http://mesa.junk-king.com">Mesa</a>, <a href="http://phoenix.junk-king.com">Phoenix</a> and <a href="http://coloradosprings.junk-king.com">Colorado Springs</a>

Change them to locations/name
<a href="/locations/middlesex/">Massachusetts</a>, <a href="/locations/mesa/">Mesa</a>, <a href="/locations/phoenix/">Phoenix</a> and <a href="/locations/coloradosprings/">Colorado Springs</a>

## Screenshots (if appropriate):
![image](https://github.com/UpendoVentures/HubSpot-EasyDnnNews-Blog-Migrator/assets/48692645/ea3c2bc3-7847-42bb-96d0-525764424f7d)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.