### PR TITLE
Fix blog links

### DIFF
--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Constants/Constant.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Constants/Constant.cs
@@ -114,6 +114,8 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Constants
         /// The default category name.
         /// </summary>
         public const string DefaultCategoryName = "Business";
+        public const string LocationsRoute = "/locations/";
+        public const string ReplaceBlogArticle = "/blog/article/";
 
         public const string Hyphen = "-";
         public const string Period = ".";

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Controllers/EasyDNNNewsController.cs
@@ -86,5 +86,12 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Services
             var result = await _easyDNNNewsRepository.ReplaceAbsoluteUrls(parameters.DomainToReplace);
             return Ok(result);
         }
+
+        [HttpGet]
+        public async Task<IHttpActionResult> ReplaceAllSimpleUrls()
+        {
+            var result = await _easyDNNNewsRepository.ReplaceSimpleUrls();
+            return Ok(result);
+        }
     }
 }

--- a/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
+++ b/Modules/HubSpotEasyDnnNewsBlogMigrator/Repository/Contract/IEasyDNNNewsRepository.cs
@@ -29,5 +29,6 @@ namespace UpendoVentures.Modules.HubSpotEasyDnnNewsBlogMigrator.Repository.Contr
         Task<int> RemoveDuplicateImages();
         Task<int> ReplaceImageUrls(string domainToReplace, string partialPath, int skipSegments);
         Task<int> ReplaceAbsoluteUrls(string domainToReplace);
+        Task<int> ReplaceSimpleUrls();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
It looks like a number of HubSpot posts contain relative urls to other posts that result in an unhandled exceptions. 

## Description

- Implemented a new ReplaceSimpleLink method to reorganize the structure of links in blog content, especially to change the way links are organized. Which prevents multiple HubSpot posts from containing URLs relative to other posts resulting in unhandled exceptions.
- Uses a regular expression to remove any date pattern in the format "/YYYY/MM/DD/" from the href value.
- Try to get the blog category name; if the blog exists, create a new route for the link.
- Add two routes for those from HubSpot, add blog/article leaving the new link blog/article/article name
- and for the others add locations/location name/blog/article/article name
- Finally, the method returns whether I updated the link or not.


## How Has This Been Tested?
I ran several tests in my local environment with the different use cases of what these links can be like.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.